### PR TITLE
Combined dependency updates (2023-08-09)

### DIFF
--- a/it/qacover-api-sample/pom.xml
+++ b/it/qacover-api-sample/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.32.3.2</version>
+			<version>3.41.2.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/net/QACover/QACover.csproj
+++ b/net/QACover/QACover.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <InformationalVersion>1.6.1-SNAPSHOT</InformationalVersion>
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 
-    <PackageReference Include="NLog" Version="5.2.2" />
+    <PackageReference Include="NLog" Version="5.2.3" />
 
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>

--- a/net/QACover/QACoverReport.csproj
+++ b/net/QACover/QACoverReport.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -60,7 +60,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     
-    <PackageReference Include="NLog" Version="5.2.2" />
+    <PackageReference Include="NLog" Version="5.2.3" />
     
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>

--- a/net/QACoverEf2spy/QACoverEf2spy.csproj
+++ b/net/QACoverEf2spy/QACoverEf2spy.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.21" />
     
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.21" />
   </ItemGroup>

--- a/net/QACoverEf2spy/QACoverEf2spy.csproj
+++ b/net/QACoverEf2spy/QACoverEf2spy.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <ProjectGuid>{BC1CF1F1-3477-4966-9A03-3A7118790DCE}</ProjectGuid>
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.20" />
     
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/net/QACoverTest/QACoverTest.csproj
+++ b/net/QACoverTest/QACoverTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
     <TargetFramework>net6.0</TargetFramework>    
     <RootNamespace />
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/net/QACoverTestEf/QACoverTestEf.csproj
+++ b/net/QACoverTestEf/QACoverTestEf.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.21" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 

--- a/net/QACoverTestEf/QACoverTestEf.csproj
+++ b/net/QACoverTestEf/QACoverTestEf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>    
     <TargetFramework>net6.0</TargetFramework>    
     <RootNamespace />
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.20">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.21">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/net/QACoverTestEf/QACoverTestEf.csproj
+++ b/net/QACoverTestEf/QACoverTestEf.csproj
@@ -16,7 +16,7 @@
     
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.21" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 			<dependency>
 				<groupId>commons-dbutils</groupId>
 				<artifactId>commons-dbutils</artifactId>
-				<version>1.7</version>
+				<version>1.8.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump commons-dbutils:commons-dbutils from 1.7 to 1.8.0](https://github.com/giis-uniovi/qacover/pull/21)
- [Bump org.xerial:sqlite-jdbc from 3.32.3.2 to 3.41.2.2 in /it/qacover-api-sample](https://github.com/giis-uniovi/qacover/pull/20)
- [Bump Microsoft.EntityFrameworkCore.Design from 6.0.20 to 6.0.21 in /net](https://github.com/giis-uniovi/qacover/pull/23)
- [Bump Microsoft.EntityFrameworkCore.Relational from 6.0.20 to 6.0.21 in /net](https://github.com/giis-uniovi/qacover/pull/24)
- [Bump Microsoft.EntityFrameworkCore.Sqlite from 6.0.20 to 6.0.21 in /net](https://github.com/giis-uniovi/qacover/pull/25)
- [Bump Microsoft.EntityFrameworkCore from 6.0.20 to 6.0.21 in /net](https://github.com/giis-uniovi/qacover/pull/22)
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 in /net](https://github.com/giis-uniovi/qacover/pull/17)
- [Bump NLog from 5.2.2 to 5.2.3 in /net](https://github.com/giis-uniovi/qacover/pull/18)
- [Bump NLog from 5.2.2 to 5.2.3 in /net/QACover](https://github.com/giis-uniovi/qacover/pull/19)