### PR TITLE
Combined dependency updates (2023-08-18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
   test-java:
     runs-on: ubuntu-latest
     #if: ${{ false }}  # disable for now
-    #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'))
     strategy:
       matrix:
         scope: [UT, Postgres, Sqlserver, Oracle]
@@ -147,8 +145,6 @@ jobs:
   test-IT:
     runs-on: ubuntu-latest
     #if: ${{ false }}  # disable for now
-    #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'))
     permissions:
       checks: write
       
@@ -218,8 +214,6 @@ jobs:
   test-net:
     runs-on: ubuntu-latest
     #if: ${{ false }}  # disable for now
-    #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || github.actor == 'dependabot[bot]'))
     permissions:
       checks: write
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -405,7 +405,7 @@ jobs:
       - name: Deploy to GitHub Pages
         if: always()
         id: deployment
-        uses: actions/deploy-pages@v2.0.3
+        uses: actions/deploy-pages@v2.0.4
         
   sonarqube:
     needs: [test-java]

--- a/net/QACover/QACover.csproj
+++ b/net/QACover/QACover.csproj
@@ -51,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PortableCs" Version="2.2.0" />
+    <PackageReference Include="PortableCs" Version="2.2.2" />
 
     <PackageReference Include="TdRules" Version="4.0.0" />
   </ItemGroup>

--- a/net/QACover/QACoverReport.csproj
+++ b/net/QACover/QACoverReport.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PortableCs" Version="2.2.0" />
+    <PackageReference Include="PortableCs" Version="2.2.2" />
 
     <PackageReference Include="TdRules" Version="4.0.0" />
   </ItemGroup>

--- a/net/QACoverTest/QACoverTest.csproj
+++ b/net/QACoverTest/QACoverTest.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/net/QACoverTestEf/QACoverTestEf.csproj
+++ b/net/QACoverTestEf/QACoverTestEf.csproj
@@ -16,7 +16,7 @@
     
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.21" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
 
     <PackageReference Include="NUnit" Version="3.13.3" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 			<dependency>
 				<groupId>com.oracle.database.jdbc</groupId>
 				<artifactId>ojdbc8</artifactId>
-				<version>21.10.0.0</version>
+				<version>21.11.0.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 2.0.3 to 2.0.4](https://github.com/giis-uniovi/qacover/pull/27)
- [Bump com.oracle.database.jdbc:ojdbc8 from 21.10.0.0 to 21.11.0.0](https://github.com/giis-uniovi/qacover/pull/28)
- [Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 in /net](https://github.com/giis-uniovi/qacover/pull/31)
- [Bump PortableCs from 2.2.0 to 2.2.2 in /net](https://github.com/giis-uniovi/qacover/pull/30)
- [Bump PortableCs from 2.2.0 to 2.2.2 in /net/QACover](https://github.com/giis-uniovi/qacover/pull/29)