### PR TITLE
Combined dependency updates (2023-08-26)

### DIFF
--- a/net/QACover/QACover.csproj
+++ b/net/QACover/QACover.csproj
@@ -53,7 +53,7 @@
   <ItemGroup>
     <PackageReference Include="PortableCs" Version="2.2.2" />
 
-    <PackageReference Include="TdRules" Version="4.0.0" />
+    <PackageReference Include="TdRules" Version="4.0.1" />
   </ItemGroup>
   
 </Project>

--- a/net/QACover/QACoverReport.csproj
+++ b/net/QACover/QACoverReport.csproj
@@ -54,7 +54,7 @@
   <ItemGroup>
     <PackageReference Include="PortableCs" Version="2.2.2" />
 
-    <PackageReference Include="TdRules" Version="4.0.0" />
+    <PackageReference Include="TdRules" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
 						<dependency>
 							<groupId>org.apache.ant</groupId>
 							<artifactId>ant-junit</artifactId>
-							<version>1.10.13</version>
+							<version>1.10.14</version>
 						</dependency>
 						<dependency>
 							<groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 			<dependency>
 				<groupId>io.github.giis-uniovi</groupId>
 				<artifactId>tdrules-bom</artifactId>
-				<version>4.0.0</version>
+				<version>4.0.1</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 			<dependency>
 				<groupId>org.xerial</groupId>
 				<artifactId>sqlite-jdbc</artifactId>
-				<version>3.42.0.0</version>
+				<version>3.42.0.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.ant:ant-junit from 1.10.13 to 1.10.14](https://github.com/giis-uniovi/qacover/pull/34)
- [Bump org.xerial:sqlite-jdbc from 3.42.0.0 to 3.42.0.1](https://github.com/giis-uniovi/qacover/pull/35)
- [Bump TdRules from 4.0.0 to 4.0.1 in /net/QACover](https://github.com/giis-uniovi/qacover/pull/37)
- [Bump TdRules from 4.0.0 to 4.0.1 in /net](https://github.com/giis-uniovi/qacover/pull/36)