### PR TITLE
Combined dependency updates (2024-02-10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,11 +398,11 @@ jobs:
       # Some files (e.g. junit reports) have 600 permissions.
       # As of upload-pages-artifact@v1.0.9, permissions must be set explicitly
       # to 0755 (as indicated in warnings produced by v1.0.8)
-      - name: Fix permissions to actions/upload-pages-artifact@v3.0.0
+      - name: Fix permissions to actions/upload-pages-artifact@v3.0.1
         run: sudo chmod -c -R 0755 target-ALL/site
       - name: Upload artifact
         if: always()
-        uses: actions/upload-pages-artifact@v3.0.0
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: 'target-ALL/site'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -408,7 +408,7 @@ jobs:
       - name: Deploy to GitHub Pages
         if: always()
         id: deployment
-        uses: actions/deploy-pages@v4.0.3
+        uses: actions/deploy-pages@v4.0.4
         
   sonarqube:
     needs: [test-java]

--- a/net/QACoverTest/QACoverTest.csproj
+++ b/net/QACoverTest/QACoverTest.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
     <PackageReference Include="NUnit" Version="4.0.1" />
 

--- a/net/QACoverTestEf/QACoverTestEf.csproj
+++ b/net/QACoverTestEf/QACoverTestEf.csproj
@@ -16,7 +16,7 @@
     
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.26" />
 
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 
     <PackageReference Include="NUnit" Version="4.0.1" />
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>2.0.11</version> <!--$NO-MVN-MAN-VER$-->
+				<version>2.0.12</version> <!--$NO-MVN-MAN-VER$-->
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/deploy-pages from 4.0.3 to 4.0.4](https://github.com/giis-uniovi/qacover/pull/146)
- [Bump actions/upload-pages-artifact from 3.0.0 to 3.0.1](https://github.com/giis-uniovi/qacover/pull/149)
- [Bump org.slf4j:slf4j-api from 2.0.11 to 2.0.12](https://github.com/giis-uniovi/qacover/pull/147)
- [Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 in /net](https://github.com/giis-uniovi/qacover/pull/148)