### PR TITLE
Methods to reset all coverage measures (closed #524)

### DIFF
--- a/qacover-core/src/test/java/test4giis/qacover/TestEvaluationStandalone.java
+++ b/qacover-core/src/test/java/test4giis/qacover/TestEvaluationStandalone.java
@@ -255,6 +255,51 @@ public class TestEvaluationStandalone {
 		assertSummary(model, "count=1,dead=1,qrun=3 count=3,dead=2");
 	}
 
+	// Scenario to check the rule coverage evolution and reset values
+	@Test
+	public void testResetMut() throws SQLException {
+		setupTestData();
+		TdRules rules = getRules("mutation", "select id,num,text from test where num=0 or text is null order by id",
+				"select id,num,text from test where num<>50 order by id");
+		QueryModel model = new QueryModel(rules);
+
+		// none covered, only count runs
+		evaluator.evaluate(model);
+		assertSummary(model, "count=1,dead=0,qrun=1 count=1,dead=0");
+			
+		// reset, all counts to 0 again
+		model.reset();
+		evaluator.evaluate(model);
+		assertSummary(model, "count=0,dead=0,qrun=0 count=0,dead=0");
+		
+		// dead, query returns more rows than rule
+		rules.getRules().get(0).query("select id,num,text from test where num=0 order by id");
+		evaluator.evaluate(model);
+		assertSummary(model, "count=1,dead=1,qrun=1 count=1,dead=1");
+
+		// reset again
+		model.reset();
+		evaluator.evaluate(model);
+		assertSummary(model, "count=0,dead=0,qrun=0 count=0,dead=0");
+			
+		// dead, query returns less rows than rule
+		rules.getRules().get(0).query("select id,num,text from test where num>=0 order by id");
+		evaluator.evaluate(model);
+		assertSummary(model, "count=1,dead=1,qrun=1 count=1,dead=1");
+
+		// Final check to verify each measure in query and a rule
+		assertEquals(1, model.getCount());
+		assertEquals(1, model.getDead());
+		assertEquals(1, model.getQrun());
+		assertEquals(0, model.getError());
+		assertEquals("", model.getErrorString());
+
+		assertEquals(1, model.getRules().get(0).getCount());
+		assertEquals(1, model.getRules().get(0).getDead());
+		assertEquals(0, model.getRules().get(0).getError());
+		assertEquals("", model.getRules().get(0).getErrorString());
+	}
+
 	@Test
 	public void testMutEmptyRows() throws SQLException {
 		setupTestData();

--- a/qacover-core/src/test/java/test4giis/qacover/TestEvaluationStandalone.java
+++ b/qacover-core/src/test/java/test4giis/qacover/TestEvaluationStandalone.java
@@ -269,7 +269,6 @@ public class TestEvaluationStandalone {
 			
 		// reset, all counts to 0 again
 		model.reset();
-		evaluator.evaluate(model);
 		assertSummary(model, "count=0,dead=0,qrun=0 count=0,dead=0");
 		
 		// dead, query returns more rows than rule
@@ -279,7 +278,6 @@ public class TestEvaluationStandalone {
 
 		// reset again
 		model.reset();
-		evaluator.evaluate(model);
 		assertSummary(model, "count=0,dead=0,qrun=0 count=0,dead=0");
 			
 		// dead, query returns less rows than rule

--- a/qacover-model/src/main/java/giis/qacover/model/QueryModel.java
+++ b/qacover-model/src/main/java/giis/qacover/model/QueryModel.java
@@ -123,7 +123,7 @@ public class QueryModel extends RuleBase {
 	public String getSourceLocation() {
 		return getAttribute(SOURCE_FILE_NAME);
 	}
-
+	
 	/**
 	 * Returns all rules stored, wrapped as RuleModel objects
 	 */
@@ -134,6 +134,14 @@ public class QueryModel extends RuleBase {
 		return rules;
 	}
 
+	/**
+	 * Reset values dead, count and error of all rules
+	 */
+	public void reset(){	
+		for (RuleModel rule : getRules())
+			rule.reset();
+	}
+	
 	public String getErrorString() {
 		return model.getError();
 	}

--- a/qacover-model/src/main/java/giis/qacover/model/QueryModel.java
+++ b/qacover-model/src/main/java/giis/qacover/model/QueryModel.java
@@ -138,6 +138,10 @@ public class QueryModel extends RuleBase {
 	 * Reset values dead, count and error of all rules
 	 */
 	public void reset(){	
+		super.setCount(0);
+		super.setDead(0);
+		super.setError(0);
+		
 		for (RuleModel rule : getRules())
 			rule.reset();
 	}

--- a/qacover-model/src/main/java/giis/qacover/model/QueryModel.java
+++ b/qacover-model/src/main/java/giis/qacover/model/QueryModel.java
@@ -108,6 +108,9 @@ public class QueryModel extends RuleBase {
 	public int getQrun() {
 		return getIntAttribute(QRUN);
 	}
+	public void setQrun(int value) {
+		setAttribute(QRUN, JavaCs.numToString(value));
+	}
 	public void addQrun(int value) {
 		incrementIntAttribute(QRUN, value);
 	}
@@ -141,6 +144,7 @@ public class QueryModel extends RuleBase {
 		super.setCount(0);
 		super.setDead(0);
 		super.setError(0);
+		setQrun(0);
 		
 		for (RuleModel rule : getRules())
 			rule.reset();

--- a/qacover-model/src/main/java/giis/qacover/model/RuleModel.java
+++ b/qacover-model/src/main/java/giis/qacover/model/RuleModel.java
@@ -79,6 +79,15 @@ public class RuleModel extends RuleBase {
 	public String getErrorString() {
 		return model.getError();
 	}
+	
+	/**
+	 *  Reset values of this rule
+	 */
+	public void reset() {
+		super.setDead(0);
+		super.setCount(0);
+		super.setError(0);
+	}
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
- New method reset in class RuleModel: set dead, count and error to 0
- New method setQrun class QueryModel
- New method reset in class QueryModel: call reset for each query and set dead, count, error and qrun to 0
- Test the reset of coverage measures